### PR TITLE
Fix dispatcher registerAction for Profiles

### DIFF
--- a/highlightsync.koplugin/main.lua
+++ b/highlightsync.koplugin/main.lua
@@ -66,7 +66,7 @@ end
 
 
 function Highlightsync:onDispatcherRegisterActions()
-    Dispatcher:registerAction("hightlightsync_action", {category="none", event="Highlightsync", title=_("Highlight Sync"), general=true,})
+    Dispatcher:registerAction("hightlightsync_action", {category="none", event="SyncBookHighlights", title=_("Highlight Sync"), reader=true,})
 end
 
 Highlightsync.default_settings = {


### PR DESCRIPTION
Just some small tweaks to get the Highlight Sync to show up in the Profiles list.  I'm not terribly familiar with Koreader internals so these changes come from comparing and fiddling.  Seems to work, though.

- update the category to `none`
- update the name of the event (it seems to look for the `onSyncBookHighlights` function name w/o the `on`)
- move the action to the `reader` section as that's where it's applicable (same place as pushing progress to the sync service)

The plugin is working great, btw!  Thanks for sharing.