### PR TITLE
Fixes possible nil reference in generate_key

### DIFF
--- a/highlightsync.koplugin/merge.lua
+++ b/highlightsync.koplugin/merge.lua
@@ -24,7 +24,7 @@ end
 -- Criação de chave mais eficiente e com menor risco de colisão
 local function generate_key(highlight)
     local text = highlight.text or ""
-    local hash = tostring(#text) .. ":" .. (highlight.text:sub(1, 10) or "")
+    local hash = tostring(#text) .. ":" .. (text:sub(1, 10) or "")
     return string.format("%s|%s", highlight.pageno or "?", hash)
 end
 


### PR DESCRIPTION
Syncing on a Kobo Libra Colour and an Android device resulted in an error in the Kobo crash.log file:

`ERROR failed to call event handler onSync plugins/highlightsync.koplugin/merge.lua:27: attempt to index field 'text' (a nil value)`

This is caused by not using the nil safe variable `text` defined in line 26 of `merge.lua`

Implementing this fixes the issue on both devices