### PR TITLE
fix: use pos0+pos1 for stable highlight keys across devices

### DIFF
--- a/highlightsync.koplugin/merge.lua
+++ b/highlightsync.koplugin/merge.lua
@@ -21,11 +21,18 @@ local function get_newer(item1, item2)
     return t1 >= t2 and item1 or item2
 end
 
--- Criação de chave mais eficiente e com menor risco de colisão
+-- Generate a stable key using pos0+pos1 (XPath positions) which are consistent
+-- across devices regardless of font size, screen size, or page layout settings.
+-- Falls back to page + text hash for older annotations without position data.
 local function generate_key(highlight)
+    -- Use pos0 + pos1 as primary key (stable across devices)
+    if highlight.pos0 and highlight.pos1 then
+        return string.format("%s|%s", highlight.pos0, highlight.pos1)
+    end
+    -- Fallback: use page + text hash for annotations without position data
     local text = highlight.text or ""
-    local hash = tostring(#text) .. ":" .. (highlight.text:sub(1, 10) or "")
-    return string.format("%s|%s", highlight.pageno or "?", hash)
+    local hash = tostring(#text) .. ":" .. (text:sub(1, 20) or "")
+    return string.format("%s|%s", highlight.page or "?", hash)
 end
 
 local function convert_to_map(highlights)


### PR DESCRIPTION
## Fix: Use stable highlight keys for cross-device sync

### 🐛 The Issue
When syncing highlights between two devices (e.g., a Kindle and an Android phone), users were experiencing **duplicate highlights**. 

Even though the highlight content was identical, the sync logic treated them as *different* highlights if the **page number** differed between devices. 

In KOReader, `pageno` is dynamic—it changes based on font size, screen dimensions, and line spacing. This made it a poor candidate for a unique identifier.

---

### 🔍 detailed Comparison & Analysis

Here is the exact JSON data that caused the duplication, showing how the **same highlight** appears on two different devices.

| Field | Device A (Kindle) | Device B (Android) | Status |
| :--- | :--- | :--- | :--- |
| **`pageno`** | `161` | `416` | ❌ **MISMATCH** |
| `pos0` | `/body/.../p[323]/text().112` | `/body/.../p[323]/text().112` | ✅ Match |
| `pos1` | `/body/.../p[324]/text().120` | `/body/.../p[324]/text().120` | ✅ Match |
| `text` | "我赤着脚..." | "我赤着脚..." | ✅ Match |
| `datetime` | `2026-01-04 22:09:52` | `2026-01-04 22:09:52` | ✅ Match |

#### Why duplication happened (The "Before" logic)
The previous code generated a unique key for each highlight using this formula:
`Key = [pageno] | [text_length] : [first_10_chars]`

- **Device A Key:** `161|122:我赤着脚从桑提亚`
- **Device B Key:** `416|122:我赤着脚从桑提亚`

Result: The merge logic sees two distinct keys and preserves both, resulting in duplicates.

---

### 🛠️ The Fix ("After" logic)

We now use **XPath positions (`pos0`, `pos1`)** as the primary unique identifier. These point to the specific DOM node in the document structure, which is **stable** regardless of how the book is rendered.

**New Key Formula:**
`Key = [pos0] | [pos1]`

- **Device A Key:** `/body/.../p[323]/text().112|/body/.../p[324]/text().120`
- **Device B Key:** `/body/.../p[323]/text().112|/body/.../p[324]/text().120`

Result: Both devices generate the **exact same key**. The merge logic correctly identifies them as the same highlight and merges them instead of duplicating.

#### Fallback Mechanism
For older annotations that might not have `pos0/pos1` data, the code falls back to the old method (using `page` instead of `pageno` where possible, or just text hash) to ensure backward compatibility.
