### PR TITLE
fix: use nextTick instead of tickAfterNext for highlight rendering

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -203,8 +203,8 @@ function Highlightsync:onSync(local_path, cached_path, income_path, reload)
         self.ui.annotation.annotations = DataAnnotations
         if reload then
             is_reloading_due_to_sync = true
-            UIManager:tickAfterNext(function()
-            self.ui:reloadDocument()
+            UIManager:nextTick(function()
+                self.ui:reloadDocument()
             end)
         end
     end


### PR DESCRIPTION
Hey! I was having an issue where highlights wouldn't render after sync — had to resize fonts every time to force a re-render.

I used AI to help me dig into the root cause: `tickAfterNext()` defers the document reload by two UI cycles, creating a window where KOReader caches stale display state without the new highlights. Switching to `nextTick()` schedules the reload on the very next cycle, preventing the stale cache.

## Test plan

- [ ] Create highlights on Device A, sync to cloud, sync on Device B — highlights should render immediately without font resize
- [ ] Test sync on book open, close, and resume settings