### PR TITLE
Skip reload when merge produces no local changes

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -194,7 +194,12 @@ function Highlightsync:onSync(local_path, cached_path, income_path, reload)
     local cached_highlights = read_json_file(cached_path) or {}
     local income_highlights = read_json_file(income_path) or {}
 
-    local annotations = Merge.Merge_highlights(local_highlights,income_highlights,cached_highlights)
+    local annotations, local_changed = Merge.Merge_highlights(local_highlights, income_highlights, cached_highlights)
+
+    if not local_changed then
+        logger.dbg("Highlightsync: no changes after merge, skipping reload")
+        return true
+    end
 
     write_json_file(SidecarDir .. "/" .. FileName .. ".json", annotations) -- Save annotations local
     DataAnnotations = annotations
@@ -208,7 +213,7 @@ function Highlightsync:onSync(local_path, cached_path, income_path, reload)
             end)
         end
     end
-  
+
     return true
 end
 

--- a/merge.lua
+++ b/merge.lua
@@ -18,7 +18,11 @@ end
 local function get_newer(item1, item2)
     local t1 = parse_datetime(get_datetime(item1))
     local t2 = parse_datetime(get_datetime(item2))
-    return t1 >= t2 and item1 or item2
+    if t1 > t2 then return item1, true end
+    if t2 > t1 then return item2, true end
+    -- Equal timestamps: keep local to avoid false-positive change detection
+    -- (server and local are different table instances even when identical)
+    return item2, false
 end
 
 -- Generate a stable key using pos0+pos1 (XPath positions) which are consistent
@@ -50,6 +54,7 @@ local function merge_highlights(local_annotations, server_annotations, last_sync
     local last_sync_map = convert_to_map(last_sync_annotations or {})
 
     local merged = {}
+    local local_changed = false
 
     -- Processa os highlights locais
     for key, local_highlight in pairs(local_map) do
@@ -57,6 +62,9 @@ local function merge_highlights(local_annotations, server_annotations, last_sync
         local last_sync_highlight = last_sync_map[key]
         if not (server_highlight == nil and last_sync_highlight ~= nil) then
             merged[key] = local_highlight
+        else
+            -- Deleted on server since last sync
+            local_changed = true
         end
     end
 
@@ -67,8 +75,13 @@ local function merge_highlights(local_annotations, server_annotations, last_sync
         else
             if not local_map[key] then
                 merged[key] = server_highlight
+                local_changed = true
             else
-                merged[key] = get_newer(server_highlight, local_map[key])
+                local newer, changed = get_newer(server_highlight, local_map[key])
+                merged[key] = newer
+                if changed then
+                    local_changed = true
+                end
             end
         end
     end
@@ -105,7 +118,7 @@ local function merge_highlights(local_annotations, server_annotations, last_sync
         return a.pos0 < b.pos0
     end)
 
-    return merged_annotations
+    return merged_annotations, local_changed
 end
 
 local M = {}


### PR DESCRIPTION
When syncing highlights, the plugin previously always wrote the merged JSON and reloaded the document — even when the merge produced no actual changes to local annotations. This caused unnecessary document reloads on every sync.

## Changes

- `get_newer()` now returns `(item, changed)` to fix false-positive change detection (Lua table identity comparison always returned true for different server/local objects with equal timestamps)
- `merge_highlights()` tracks and returns a `local_changed` flag across all three change paths (server-deleted, new-from-server, server-newer)
- `onSync()` early-returns when no changes, skipping JSON write and document reload