### PR TITLE
fix: skip auto-sync on book open/close when WiFi is off

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -154,7 +154,11 @@ function Highlightsync:onReaderReady()
 
     if self.settings.sync_on_open and self:canSync() then
         UIManager:nextTick(function()
-            self:SyncBookHighlights(false, true)
+            -- Only sync if WiFi is already on; avoid forcing WiFi on (or
+            -- erroring out) when the book is opened offline. Mirrors onResume.
+            if NetworkMgr:isWifiOn() then
+                self:SyncBookHighlights(false, true)
+            end
         end)
     end
 end
@@ -168,7 +172,11 @@ function Highlightsync:onCloseDocument()
 
     if self.settings.sync_on_close and self:canSync() then
         -- Sincroniza e sai (sem reload, pois estamos saindo)
-        self:SyncBookHighlights(false, false) 
+        -- Only sync if WiFi is already on; avoid forcing WiFi on (or
+        -- erroring out) when the book is closed offline. Mirrors onResume.
+        if NetworkMgr:isWifiOn() then
+            self:SyncBookHighlights(false, false)
+        end
     end
 end
 


### PR DESCRIPTION
## Problem

`onResume` already guards the sync call with `NetworkMgr:isWifiOn()`, but the two other auto-sync triggers do not:

- `onReaderReady` (sync on open) → `self:SyncBookHighlights(false, true)` with no network check
- `onCloseDocument` (sync on close) → `self:SyncBookHighlights(false, false)` with no network check

When a book is opened or closed while offline, `SyncService.sync` runs `NetworkMgr:willRerunWhenOnline(...)`, which — with the common `wifi_enable_action = "turn_on"` setting — **forces a WiFi connection attempt** on every open/close, or otherwise surfaces the *"Something went wrong when syncing, please check your network connection"* error. On e-ink readers that keep WiFi off to save battery, this makes "sync on open/close" unpleasant to use.

## Fix

Wrap the open/close sync calls in `if NetworkMgr:isWifiOn() then ... end`, exactly mirroring the existing `onResume` guard. Automatic sync now runs only when WiFi is already on, and silently no-ops when offline — no forced WiFi, no error popups. Manual "Sync Highlights" is unchanged (it still connects on demand, as expected for an explicit user action).

`NetworkMgr` is already imported in `main.lua`, so no new requires. Verified with `luac -p`.

## Behavior summary

| Trigger | Before (offline) | After (offline) |
|---|---|---|
| Sync on open | forces WiFi / error | silently skips |
| Sync on close | forces WiFi / error | silently skips |
| Sync on resume | already skips | unchanged |
| Manual sync | connects on demand | unchanged |